### PR TITLE
handle roks workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The module depends on the following software components:
 
 - terraform >= v0.15
 - kubectl
+- ibmcloud cli (for ROKS cluster reboots)
 
 #### Terraform providers
 
@@ -36,6 +37,8 @@ This module makes use of the output from other modules:
 module "ocp_proxy_module" {
 
   ibmcloud_api_key    = var.ibmcloud_api_key
+  resource_group_name = module.resource_group.name
+  region              = var.region
   roks_cluster        = true
   proxy-host          = module.proxy.proxy-host
   proxy-port          = module.proxy.proxy-port

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,6 @@
 locals {
-  tmp_dir           = "${path.cwd}/.tmp"
+  tmp_dir          = "${path.cwd}/.tmp"
+  crio_config_file = "${local.tmp_dir}/crio-config.yaml"
   proxy-config = templatefile("${path.module}/templates/_template_proxy-config.yaml", {
     "proxy_ip"       = var.proxy-host,
     "proxy_port"     = var.proxy-port,
@@ -11,15 +12,31 @@ locals {
     "cluster_local"         = var.allow_network,
     "ocp_release_dev_image" = var.ocp-release-dev-image
   })
+  crio-unconfig = templatefile("${path.module}/templates/_template_rmcrioproxy.yaml", {
+    "ocp_release_dev_image" = var.ocp-release-dev-image
+  })
 }
 
+## Standard proxy config file for OCP
 resource "local_file" "proxy-config" {
   filename = "${local.tmp_dir}/proxy-config.yaml"
   content  = local.proxy-config
 }
 
+## Config file for ROKS - daemonset to patch crio networking to use proxy
+resource "local_file" "crio-config" {
+  filename = "${local.tmp_dir}/crio-config.yaml"
+  content  = local.crio-config
+}
 
-resource null_resource apply-proxy-config {
+## Config file for ROKS - daemonset to remove modifications to crio networking
+resource "local_file" "crio-unconfig" {
+  filename = "${local.tmp_dir}/crio-unconfig.yaml"
+  content  = local.crio-unconfig
+}
+
+## Apply to all OpenShift Clusters
+resource "null_resource" "apply-proxy-config" {
   depends_on = [local_file.proxy-config]
 
   triggers = {
@@ -43,4 +60,90 @@ resource null_resource apply-proxy-config {
       KUBECONFIG = self.triggers.kubeconfig
     }
   }
+}
+
+resource "null_resource" "apply-crio-config" {
+  depends_on = [local_file.crio-config, local_file.crio-unconfig]
+
+  count = var.roks_cluster ? 1 : 0
+
+  triggers = {
+    kubeconfig          = var.cluster_config_file
+    crio-config-file    = "${local.tmp_dir}/crio-config.yaml"
+    ibmcloud_api_key    = var.ibmcloud_api_key
+    cluster_name        = var.cluster_name
+    region              = var.region
+    resource_group_name = var.resource_group_name
+    crio-unconfig-file  = "${local.tmp_dir}/crio-unconfig.yaml"
+  }
+
+  ### first three provisioners ensure ROKS workers have crio-config and are rebooted to use proxy
+  provisioner "local-exec" {
+    command = "kubectl apply -f ${local.tmp_dir}/crio-config.yaml"
+
+    environment = {
+      KUBECONFIG = var.cluster_config_file
+    }
+  }
+
+  provisioner "local-exec" {
+    command = "kubectl rollout status daemonset -n kube-system https-proxy-mod --timeout 120s"
+
+    environment = {
+      KUBECONFIG = var.cluster_config_file
+    }
+  }
+
+  provisioner "local-exec" {
+    command = "${path.module}/scripts/reboot-roks-workers.sh '${var.region}' '${var.resource_group_name}'"
+
+    environment = {
+      IBMCLOUD_API_KEY = var.ibmcloud_api_key
+      CLUSTER          = var.cluster_name
+    }
+  }
+  ### end setup for crio-config
+
+  ### provisioners to back out crio networking configuration for proxy and reboot ROKS workers
+  provisioner "local-exec" {
+    when = destroy
+
+    command = "kubectl delete -f ${self.triggers.crio-config-file} && kubectl apply -f ${self.triggers.crio-unconfig-file}"
+
+    environment = {
+      KUBECONFIG = self.triggers.kubeconfig
+    }
+  }
+
+  provisioner "local-exec" {
+    when = destroy
+
+    command = "kubectl rollout status daemonset -n kube-system https-proxy-remove --timeout 120s"
+
+    environment = {
+      KUBECONFIG = self.triggers.kubeconfig
+    }
+  }
+
+  provisioner "local-exec" {
+    when = destroy
+
+    command = "kubectl delete -f ${self.triggers.crio-unconfig-file}"
+
+    environment = {
+      KUBECONFIG = self.triggers.kubeconfig
+    }
+  }
+
+  provisioner "local-exec" {
+    when = destroy
+
+    command = "${path.module}/scripts/reboot-roks-workers.sh '${self.triggers.region}' '${self.triggers.resource_group_name}'"
+
+    environment = {
+      IBMCLOUD_API_KEY = self.triggers.ibmcloud_api_key
+      CLUSTER          = self.triggers.cluster_name
+    }
+  }
+  ### end cleanup for crio-config
 }

--- a/module.yaml
+++ b/module.yaml
@@ -1,9 +1,10 @@
-name: ""
+name: "ocp-proxyconfig"
 type: terraform
-description: ""
+description: "Configure OpenShift Cluster to use a HTTP tunnel proxy for outbound traffic"
 tags:
-    - tools
-    - devops
+    - network
+    - proxy
+    - egress
 versions:
 - platforms: []
 #  providers:

--- a/scripts/reboot-roks-workers.sh
+++ b/scripts/reboot-roks-workers.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+REGION="$1"
+RESOURCE_GROUP="$2"
+
+if [[ -z "${IBMCLOUD_API_KEY}" ]]; then
+  echo "IBMCLOUD_API_KEY environment variable must be set"
+  exit 1
+fi
+
+ibmcloud login --apikey ${IBMCLOUD_API_KEY} -r ${REGION} -g ${RESOURCE_GROUP} -q
+
+# do a rolling action of all workers
+echo "Performing rolling reboot of workers, 5 min wait after each action"
+for WORKER in $(ibmcloud cs worker ls --cluster ${CLUSTER} | grep kube | cut -d' ' -f1); do
+    echo "rebooting $WORKER..."
+    ibmcloud cs worker reboot -f --skip-master-health --worker $WORKER --cluster ${CLUSTER};
+    sleep 300;
+done

--- a/templates/_template_rmcrioproxy.yaml
+++ b/templates/_template_rmcrioproxy.yaml
@@ -1,27 +1,25 @@
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
-  name: https-proxy-mod
+  name: https-proxy-remove
   namespace: kube-system
   labels:
     tier: management
-    app: https-proxy-mod
+    app: https-proxy-remove
 spec:
   selector:
     matchLabels:
-      name: https-proxy-mod
+      name: https-proxy-remove
   template:
     metadata:
       labels:
-        name: https-proxy-mod
+        name: https-proxy-remove
     spec:
       initContainers:
         - command: ["/bin/sh", "-c"]
           args:
             - >
-              echo NO_PROXY="${cluster_local},cluster.local,.svc,localhost,127.0.0.1,172.20.0.1,172.21.0.0/16,172.17.0.0/18,161.26.0.0/16,166.8.0.0/14,172.20.0.0/16"  > /host/etc/sysconfig/crio-network;
-              echo HTTP_PROXY="http://${proxy_ip}:${proxy_port}/" >> /host/etc/sysconfig/crio-network;
-              echo HTTPS_PROXY="http://${proxy_ip}:${proxy_port}/" >> /host/etc/sysconfig/crio-network;
+              rm -rf /host/etc/sysconfig/crio-network
           image: ${ocp_release_dev_image}
           imagePullPolicy: IfNotPresent
           name: crio-proxy-setup

--- a/test/stages/stage2-mymodule.tf
+++ b/test/stages/stage2-mymodule.tf
@@ -1,18 +1,13 @@
 module "ocp_proxy_module" {
-  # source = "./module"
-  source = "../../"
+  source = "./module"
+  # source = "../../"
 
   ibmcloud_api_key    = var.ibmcloud_api_key
+  resource_group_name = module.resource_group.name
+  region              = var.region
   proxy-host          = var.proxy-host
   proxy-port          = var.proxy-port
   cluster_config_file = module.dev_cluster.platform.kubeconfig
+  cluster_name        = module.dev_cluster.name
 }
 
-# output "cluster_config_file" {
-#   value = module.dev_cluster.config_file_path
-# }
-
-# output "preferred-cluster-config" {
-#   value = module.dev_cluster.platform.kubeconfig
-#   sensitive = true
-# }

--- a/variables.tf
+++ b/variables.tf
@@ -1,6 +1,19 @@
 variable "ibmcloud_api_key" {
   type        = string
-  description = "The IBM Cloud api token"
+  description = "The IBM Cloud api token, required for ROKS cluster rolling worker updates"
+  default     = ""
+}
+
+variable "resource_group_name" {
+  type        = string
+  description = "The resource group name, required for ROKS cluster rolling worker updates"
+  default     = ""
+}
+
+variable "region" {
+  type        = string
+  description = "The region, required for ROKS cluster rolling worker updates"
+  default     = ""
 }
 
 variable "proxy-host" {
@@ -16,6 +29,12 @@ variable "proxy-port" {
 variable "cluster_config_file" {
   type        = string
   description = "Cluster config file for Kubernetes cluster"
+}
+
+variable "cluster_name" {
+  type        = string
+  description = "Cluster name, required for ROKS cluster rolling worker updates"
+  default     = ""
 }
 
 variable "cluster_type" {


### PR DESCRIPTION
Update for roks which requires per-worker tweaks for containers to use HTTP tunnel proxy:

1. create null provisioner to apply daemonset for crio-network 
2. rolling reboot of workers in cluster
3. clean removal with daemonset to delete crio-network, followed by rolling reboot